### PR TITLE
Generate, update Debian, remove postgres

### DIFF
--- a/generate/Dockerfile
+++ b/generate/Dockerfile
@@ -1,16 +1,12 @@
-FROM debian:jessie
+FROM debian:buster
 
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list \
- && echo 'deb http://httpredir.debian.org/debian jessie-backports main contrib' > /etc/apt/sources.list.d/backports.list \
- && DEBIAN_FRONTEND=noninteractive apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get  -t jessie-backports install -y --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     zlib1g-dev \
     cmake \
     libosmium2-dev \
     git \
-    postgresql-client \
     wget \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The Generate Docker file is no more able to build.

The `http://httpredir.debian.org/debian jessie-backports` source is no more valid.

Update to last Debian release (buster) and remove unnecessary Postgres dependency.
