### PR TITLE
Quoted admin_level since it's a string

### DIFF
--- a/import/import_osmborder_lines.sh
+++ b/import/import_osmborder_lines.sh
@@ -37,7 +37,7 @@ function generalize_border() {
     local tolerance="$3"
     local max_admin_level="$4"
     echo "Generalize $target_table_name with tolerance $tolerance from $source_table_name"
-    echo "CREATE TABLE $target_table_name AS SELECT ST_Simplify(geometry, $tolerance) AS geometry, osm_id, admin_level, dividing_line, disputed, maritime FROM $source_table_name WHERE admin_level <= $max_admin_level;" | exec_psql
+    echo "CREATE TABLE $target_table_name AS SELECT ST_Simplify(geometry, $tolerance) AS geometry, osm_id, admin_level, dividing_line, disputed, maritime FROM $source_table_name WHERE admin_level <= '$max_admin_level';" | exec_psql
     echo "CREATE INDEX ON $target_table_name USING gist (geometry);" | exec_psql
     echo "ANALYZE $target_table_name;" | exec_psql
 }


### PR DESCRIPTION
admin_level is a string on recent osm data imported with imposm.
Trying to execute the table generation in the generalize_border() function failed before this edit.